### PR TITLE
Use volume port instead volume public port when upload

### DIFF
--- a/src/SeaweedFS.php
+++ b/src/SeaweedFS.php
@@ -131,7 +131,7 @@ class SeaweedFS {
             throw new SeaweedFSException('File must contain a url and fid');
         }
 
-        $res = $this->client->post($this->buildVolumeUrl($file->publicUrl, $file->fid), [
+        $res = $this->client->post($this->buildVolumeUrl($file->url, $file->fid), [
             'multipart' => [
                 [
                     'name'     => 'file',


### PR DESCRIPTION
According to SeaweedFS wiki (and own experience) upload should handled by volume server via volume port, not public port