### PR TITLE
Allow pass other options on assign fid

### DIFF
--- a/src/SeaweedFS.php
+++ b/src/SeaweedFS.php
@@ -61,7 +61,6 @@ class SeaweedFS {
     public function assign($count = 1, $collection = null, $replication = null, $dataCenter = null) {
         $assignProperties = [ 'count' => $count ];
 
-
         if (!is_null($collection)) {
             $assignProperties['collection'] = $collection;
         }

--- a/src/SeaweedFS.php
+++ b/src/SeaweedFS.php
@@ -60,15 +60,20 @@ class SeaweedFS {
      */
     public function assign($count = 1, $collection = null, $replication = null, $dataCenter = null) {
         $assignProperties = [ 'count' => $count ];
+
+
         if (!is_null($collection)) {
             $assignProperties['collection'] = $collection;
         }
+
         if (!is_null($replication)) {
             $assignProperties['replication'] = $replication;
         }
+
         if (!is_null($dataCenter)) {
             $assignProperties['dataCenter'] = $dataCenter;
         }
+
         $res = $this->client->get($this->buildMasterUrl(self::DIR_ASSIGN), [
             'query' => $assignProperties
         ]);

--- a/src/SeaweedFS.php
+++ b/src/SeaweedFS.php
@@ -50,13 +50,27 @@ class SeaweedFS {
     /**
      * Get a volume and file id from the master server.
      *
-     * @param int $count
+     * @param int  $count
+     * @param string|null $collection
+     * @param string|null $replication
+     * @param string|null $dataCenter
      * @return File
      * @throws SeaweedFSException
+     * @see https://github.com/chrislusf/seaweedfs/wiki/Master-Server-API#assign-a-file-key
      */
-    public function assign($count = 1) {
+    public function assign($count = 1, $collection = null, $replication = null, $dataCenter = null) {
+        $assignProperties = [ 'count' => $count ];
+        if (!is_null($collection)) {
+            $assignProperties['collection'] = $collection;
+        }
+        if (!is_null($replication)) {
+            $assignProperties['replication'] = $replication;
+        }
+        if (!is_null($dataCenter)) {
+            $assignProperties['dataCenter'] = $dataCenter;
+        }
         $res = $this->client->get($this->buildMasterUrl(self::DIR_ASSIGN), [
-            'query' => [ 'count' => $count ]
+            'query' => $assignProperties
         ]);
 
         if ($res->getStatusCode() != 200) {


### PR DESCRIPTION
One important option for me (and others) is to pass some additional options when assign fid, like replication, collection or data center.

What do you think about this solution?